### PR TITLE
Fix for build error with NFFT=3.4.1

### DIFF
--- a/doc/source/api/util.rst
+++ b/doc/source/api/util.rst
@@ -20,5 +20,3 @@ Functions used for computing the density compensation weights necessary for the
 iterative solver and adjoint NFFT.
 
 .. autofunction:: pynfft.util.voronoi_weights_1d(w, x)
-
-.. autofunction:: pynfft.util.voronoi_weights_S2(w, xi)

--- a/pynfft/cnfft3util.pxd
+++ b/pynfft/cnfft3util.pxd
@@ -29,6 +29,3 @@ cdef extern from "nfft3.h":
     void nfft_voronoi_weights_1d (double *w, double *x, int M)
  	    # Computes non periodic voronoi weights, \
         # assumes ordered nodes $x_j$.
-
-    void nfft_voronoi_weights_S2(double *w, double *xi, int M)
-        # Computes voronoi weights for nodes on the sphere S^2. */

--- a/pynfft/util.pyx
+++ b/pynfft/util.pyx
@@ -63,21 +63,3 @@ def voronoi_weights_1d (object[np.float64_t, mode='c'] w not None,
         raise ValueError('Incompatible size between weights and nodes \
                          (%d, %d)'%(w.size, x.size))
     nfft_voronoi_weights_1d(<double *>&w[0], <double *>&x[0], w.size)
-
-def voronoi_weights_S2 (object[np.float64_t, mode='c'] w not None,
-                        object[np.float64_t, mode='c'] xi not None):
-    '''
-    Utilitary function for computing density compensation weights from knots
-    located on the surface of a sphere.
-
-    Useful for reconstruction of 3D radial data.
-
-    :param w: pre-allocated array
-    :type w: ndarray <float64>
-    :param xi: angular locations (2D) on the unit sphere
-    :type xi: ndarray <float64>
-    '''
-    if xi.size != 2 * w.size:
-        raise ValueError('Incompatible size between weights and nodes \
-                         (%d, %d)'%(w.size, xi.size))
-    nfft_voronoi_weights_S2(<double *>&w[0], <double *>&xi[0], w.size)


### PR DESCRIPTION
Removed a function no longer supported (voronoi_weights_S2) in the latest version of NFFT (3.4.1). I've verified that the unit tests run fine with NFFT 3.4.1